### PR TITLE
Fix demo for ongoing RAI changes.

### DIFF
--- a/prj.conf
+++ b/prj.conf
@@ -126,7 +126,7 @@ CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE=y
 # Sets the duration that the lwm2m engine will be polling for data after transmission before
 # the socket is closed.
 # Adjust so that we can detach from network in 30 seconds
-CONFIG_LWM2M_QUEUE_MODE_UPTIME=10
+CONFIG_LWM2M_QUEUE_MODE_UPTIME=30
 
 # Set lifetime of 24 hours
 CONFIG_LWM2M_ENGINE_DEFAULT_LIFETIME=86400

--- a/src/app.h
+++ b/src/app.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2023, Nordic Semiconductor ASA
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form, except as embedded into a Nordic
+*    Semiconductor ASA integrated circuit in a product or a software update for
+*    such product, must reproduce the above copyright notice, this list of
+*    conditions and the following disclaimer in the documentation and/or other
+*    materials provided with the distribution.
+*
+* 3. Neither the name of Nordic Semiconductor ASA nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* 4. This software, with or without modification, must only be used with a
+*    Nordic Semiconductor ASA integrated circuit.
+*
+* 5. Any software provided in binary form under this license must not be reverse
+*    engineered, decompiled, modified and/or disassembled.
+*
+* THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS
+* OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+* OF MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+* LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+* GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _APP_H
+#define _APP_H
+
+void send_data_to_server(void);
+
+#endif /* _APP_H */

--- a/src/custom_objects/ucifi_water_meter.c
+++ b/src/custom_objects/ucifi_water_meter.c
@@ -185,7 +185,7 @@ static struct lwm2m_engine_obj_inst *water_meter_create(uint16_t obj_inst_id)
 	// INIT_OBJ_RES(WATER_METER_CUMULATED_WATER_VOLUME_RID, res[index], i, res_inst[index], j, 1,
 	// 	     false, true, &meter_data[index].volume, sizeof(meter_data[index].volume),
 	// 	     NULL, NULL, NULL, meter_value_write_cb, NULL);
-	INIT_OBJ_RES_DATA(WATER_METER_CUMULATED_WATER_VOLUME_RID, res[index], i, res_inst[index], j, &meter_data[index].volume, 
+	INIT_OBJ_RES_DATA(WATER_METER_CUMULATED_WATER_VOLUME_RID, res[index], i, res_inst[index], j, &meter_data[index].volume,
 				sizeof(meter_data[index].volume));
 	INIT_OBJ_RES_EXECUTE(WATER_METER_CUMULATED_WATER_METER_VALUE_RESET_RID, res[index], i,
 			     reset_meter_measured_values_cb);
@@ -220,7 +220,7 @@ static struct lwm2m_engine_obj_inst *water_meter_create(uint16_t obj_inst_id)
 	return &inst[index];
 }
 
-static int ipso_water_meter_init(const struct device *dev)
+static int ipso_water_meter_init(void)
 {
 	water_meter.obj_id = UCIFI_OBJECT_WATER_METER_ID;
 	water_meter.version_major = WATER_METER_VERSION_MAJOR;

--- a/src/lwm2m/lwm2m_water_meter.c
+++ b/src/lwm2m/lwm2m_water_meter.c
@@ -110,10 +110,10 @@ void update_water_meter_value(struct meter_data val)
 extern void send_leak_detection_alert(void);
 static bool water_meter_event_handler(const struct app_event_header *aeh)
 {
-	if (is_water_meter_event(aeh)) 
+	if (is_water_meter_event(aeh))
 	{
 		struct water_meter_event *event = cast_water_meter_event(aeh);
-		if (event->type == LEAK_DETECTION_ALARM) 
+		if (event->type == LEAK_DETECTION_ALARM)
 		{
 			lwm2m_set_bool(&LWM2M_OBJ(UCIFI_OBJECT_WATER_METER_ID, 0, WATER_METER_LEAK_DETECTE_RID), true);
 		}
@@ -122,7 +122,7 @@ static bool water_meter_event_handler(const struct app_event_header *aeh)
 			lwm2m_set_bool(&LWM2M_OBJ(UCIFI_OBJECT_WATER_METER_ID, 0, WATER_METER_LEAK_DETECTE_RID), false);
 		}
 
-		send_leak_detection_alert();
+		send_data_to_server();
 
 		return true;
 	}

--- a/src/lwm2m/lwm2m_water_meter.c
+++ b/src/lwm2m/lwm2m_water_meter.c
@@ -46,6 +46,7 @@
 #include "lwm2m_app_utils.h"
 #include "meter_sensor.h"
 #include "water_meter_event.h"
+#include "app.h"
 
 LOG_MODULE_REGISTER(lwm2m_water_meter,CONFIG_APP_LOG_LEVEL);
 

--- a/src/main.c
+++ b/src/main.c
@@ -308,10 +308,6 @@ void send_data_to_server(void)
 	{
 		LOG_WRN("Upload data when lwm2m connected server!\r\n");
 	}
-
-	/**Send cell location request event */
-	struct ground_fix_location_request_event *ground_fix_event = new_ground_fix_location_request_event();
-	APP_EVENT_SUBMIT(ground_fix_event);
 }
 
 
@@ -836,6 +832,11 @@ int main(void)
 		case CONNECTING:
 			LOG_INF("LwM2M is connecting to server");
 			k_mutex_unlock(&lte_mutex);
+			{
+				/**Send cell location request event */
+				struct ground_fix_location_request_event *ground_fix_event = new_ground_fix_location_request_event();
+				APP_EVENT_SUBMIT(ground_fix_event);
+			}
 			break;
 
 		case CONNECTED:
@@ -847,11 +848,6 @@ int main(void)
 			} else {
 				k_mutex_unlock(&lte_mutex);
 				LOG_INF("LwM2M is connected to server\r\n");
-
-				if(!updating_flag)		//added by Noy
-				{
-					send_data_to_server();
-				}
 
 #if defined(CONFIG_APP_LWM2M_CONFORMANCE_TESTING)
 				lwm2m_register_server_send_mute_cb();

--- a/src/main.c
+++ b/src/main.c
@@ -511,6 +511,8 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 		return;
 	}
 
+	lwm2m_utils_connection_manage(client, &client_event);
+
 	switch (client_event) {
 	case LWM2M_RD_CLIENT_EVENT_DEREGISTER:
 	case LWM2M_RD_CLIENT_EVENT_NONE:
@@ -583,9 +585,6 @@ static void rd_client_event(struct lwm2m_ctx *client, enum lwm2m_rd_client_event
 
 	case LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF:
 		LOG_DBG("Queue mode RX window closed");
-		if (IS_ENABLED(CONFIG_LWM2M_CLIENT_UTILS_RAI)) {
-			lwm2m_rai_last();
-		}
 		k_mutex_unlock(&lte_mutex);
 		break;
 

--- a/src/sensors/meter_sensor.c
+++ b/src/sensors/meter_sensor.c
@@ -49,6 +49,7 @@
 #include <nrfx_gpiote.h>
 #include <zephyr/sys/atomic.h>
 #include "water_meter_event.h"
+#include "../app.h"
 
 LOG_MODULE_REGISTER(meter_measure,CONFIG_APP_LOG_LEVEL);
 
@@ -68,7 +69,7 @@ struct meter_data meter = {0};
 
 // static uint32_t pulse_count = 0;
 // int64_t start_time = 0;				//start time of the interrupt
-struct recoder_interval leak_recorder = { 0 };		
+struct recoder_interval leak_recorder = { 0 };
 
 static const struct gpio_dt_spec meter_pulse = GPIO_DT_SPEC_GET_OR(DT_NODELABEL(signal1), gpios, {0});
 static const struct gpio_dt_spec leak_detection = GPIO_DT_SPEC_GET_OR(SW0_NODE, gpios,{0});
@@ -103,7 +104,7 @@ static void meter_event_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t tri
 			}
 			else if (leak_recorder.interval > CONFIG_MIN_LEAK_DETECTION_INTERVAL_MS) {
 				LOG_WRN("Water flow overspeed alert!!!\n");
-			} 
+			}
 			else if (leak_recorder.interval > CONFIG_NORMAL_LEAK_DETECTION_INTERVAL_MS)
 			{
 				LOG_WRN("Normal water flow!\n");
@@ -116,7 +117,7 @@ static void meter_event_handler(nrfx_gpiote_pin_t pin, nrfx_gpiote_trigger_t tri
 					APP_EVENT_SUBMIT(alarm_event);
 				}
 			}
-		} 
+		}
 		else {
 			LOG_INF("Leak alert interrupt has been triggered, now start the time[%d]\n", gpio_pin_get_dt(&leak_detection));
 			leak_recorder.start = k_ticks_to_ms_floor64(k_uptime_ticks());
@@ -212,6 +213,3 @@ int water_meter_init(void)
 
 	return 0;
 }
-
-
-

--- a/west.yml
+++ b/west.yml
@@ -1,0 +1,8 @@
+manifest:
+  projects:
+    - name: nrf
+      url: https://github.com/SeppoTakalo/sdk-nrf
+      revision: lwm2m_rai
+      import: true
+  self:
+    path: lwm2m-water-meter


### PR DESCRIPTION
This PR contains various changes to make it work against my ongoing work branch regading RAI handling.

* Zephyr's LwM2M engine is modified to indicate about socket traffic.
* Allow LwM2M client utils to handle RAI.
* Fix build warnings.
* Don't always send Ground Fix requests.
* Don't trigger SEND on LwM2M Update. This would break the RAI indication.


For compiling, first use the west manifest inside this repository:
```
west config manifest.path lwm2m-water-meter
west update
```
This works, if this application is cloned inside `ncs/` next to the `nrf` and `zephyr`


To allow RAI to work properly:
* Make sure that only on LwM2M SEND command is queued. If there are more packets in queue, RAI breaks up.